### PR TITLE
fix: disable create database button when fields are empty COMPASS-4589

### DIFF
--- a/src/components/create-database-modal/create-database-modal.jsx
+++ b/src/components/create-database-modal/create-database-modal.jsx
@@ -248,6 +248,7 @@ class CreateDatabaseModal extends PureComponent {
             text="Cancel"
             clickHandler={this.onHide} />
           <TextButton
+            disabled={!this.props.name || !this.props.collectionName}
             className="btn btn-primary btn-sm"
             dataTestId="create-database-button"
             text="Create Database"

--- a/src/components/create-database-modal/create-database-modal.spec.js
+++ b/src/components/create-database-modal/create-database-modal.spec.js
@@ -83,8 +83,9 @@ describe('CreateDatabaseModal [Component]', () => {
       expect(component.find('.btn-default').hostNodes()).to.have.text('Cancel');
     });
 
-    it('renders the create button', () => {
+    it('renders the create button enabled', () => {
       expect(component.find('.btn-primary').hostNodes()).to.have.text('Create Database');
+      expect(component.find('.btn-primary').hostNodes()).to.not.have.attr('disabled');
     });
 
     it('renders the modal form', () => {
@@ -105,6 +106,18 @@ describe('CreateDatabaseModal [Component]', () => {
           simulate('change', 'dbName');
         expect(changeDatabaseNameSpy.calledWith('dbName')).to.equal(true);
       });
+
+      context('setting it to an empty value', () => {
+        beforeEach(() => {
+          component.setProps({
+            name: ''
+          });
+        });
+
+        it('disables the create button', () => {
+          expect(component.find('.btn-primary').hostNodes()).to.have.attr('disabled');
+        });
+      });
     });
 
     context('when changing the collection name', () => {
@@ -112,6 +125,18 @@ describe('CreateDatabaseModal [Component]', () => {
         component.find('#create-database-collection-name').hostNodes().
           simulate('change', 'collName');
         expect(changeCollectionNameSpy.calledWith('collName')).to.equal(true);
+      });
+
+      context('setting it to an empty value', () => {
+        beforeEach(() => {
+          component.setProps({
+            collectionName: ''
+          });
+        });
+
+        it('disables the create button', () => {
+          expect(component.find('.btn-primary').hostNodes()).to.have.attr('disabled');
+        });
       });
     });
 


### PR DESCRIPTION
## Description
Same as https://github.com/mongodb-js/compass-collections-ddl/pull/157 but for the new database dialog.

Fixes https://github.com/mongodb-js/compass/issues/1974, too.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
